### PR TITLE
Turn role errors into warnings

### DIFF
--- a/compiler/hsSyn/HsExpr.hs
+++ b/compiler/hsSyn/HsExpr.hs
@@ -335,9 +335,9 @@ data HsExpr p
   | HsAppTypeOut (LHsExpr p) (LHsWcType GhcRn) -- just for pretty-printing
 
   | HsAppDict    (LHsExpr p)
-                 (LHsExpr p)             -- ^ Dictionary to apply
-                 (Maybe (LHsSigType p))  -- ^ Optional type-class constraint
-                                         -- annotation of the dictionary.
+                 (LHsExpr p)             --   Dictionary to apply
+                 (Maybe (LHsSigType p))  --   Optional type-class constraint
+                                         --   annotation of the dictionary.
     -- TODOT Annotation crap
 
   -- | Operator applications:

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -749,6 +749,7 @@ data WarningFlag =
    | Opt_WarnPartialFields                -- Since 8.4
    | Opt_WarnMissingExportList
    | Opt_WarnIncoherence
+   | Opt_WarnDictAppRoles
    deriving (Eq, Show, Enum)
 
 data Language = Haskell98 | Haskell2010
@@ -3760,7 +3761,8 @@ wWarningFlagsDeps = [
   flagSpec "missing-home-modules"        Opt_WarnMissingHomeModules,
   flagSpec "unrecognised-warning-flags"  Opt_WarnUnrecognisedWarningFlags,
   flagSpec "partial-fields"              Opt_WarnPartialFields,
-  flagSpec "incoherence"                 Opt_WarnIncoherence ]
+  flagSpec "incoherence"                 Opt_WarnIncoherence,
+  flagSpec "dictionary-application-roles" Opt_WarnDictAppRoles ]
 
 -- | These @-\<blah\>@ flags can all be reversed with @-no-\<blah\>@
 negatableFlagsDeps :: [(Deprecation, FlagSpec GeneralFlag)]
@@ -4387,7 +4389,8 @@ standardWarnings -- see Note [Documenting warning flags]
         Opt_WarnTabs,
         Opt_WarnUnrecognisedWarningFlags,
         Opt_WarnSimplifiableClassConstraints,
-        Opt_WarnIncoherence
+        Opt_WarnIncoherence,
+        Opt_WarnDictAppRoles
       ]
 
 -- | Things you get with -W

--- a/compiler/typecheck/TcExpr.hs
+++ b/compiler/typecheck/TcExpr.hs
@@ -1604,25 +1604,26 @@ tcCheckDictAppRoleCriterion matched tau ctxt
          [ app_to_msg
          , text "is not allowed because the instance incoherence check"
          , text "requires type-variable arguments" ]
-       ; unless ok $ do {
+       ; warn <- woptM Opt_WarnDictAppRoles
+       ; unless (not warn || ok) $ do {
          -- TODO mention in the error message that the type variable doesn't
          -- occur in all superclasses
        ; let nominals_in_tau  = [tv | (tv, Nominal) <- tvs_with_roles_in_tau]
              nominals_in_dict = [tv | (tv, Nominal) <- tvs_with_roles_in_dict]
              nominals_in_ctxt = [tv | (tv, Nominal) <- tvs_with_roles_in_ctxt]
-       ; unless (null nominals_in_tau) $ addWarnTc $ vcat $
+       ; unless (null nominals_in_tau) $ addWarnTc (Reason Opt_WarnDictAppRoles) $ vcat $
          not_allowed_msg ++
          [ text "In the function type" <+> quotes (ppr tau)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>
                            text "has role Nominal"
                          | tv <- nominals_in_tau]]
-       ; unless (null nominals_in_dict) $ addWarnTc $ vcat $
+       ; unless (null nominals_in_dict) $ addWarnTc (Reason Opt_WarnDictAppRoles) $ vcat $
          not_allowed_msg ++
          [ text "In the dictionary type" <+> quotes (ppr dict)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>
                            text "has role Nominal"
                          | tv <- nominals_in_dict]]
-       ; unless (null nominals_in_ctxt) $ addWarnTc $ vcat $
+       ; unless (null nominals_in_ctxt) $ addWarnTc (Reason Opt_WarnDictAppRoles) $ vcat $
          not_allowed_msg ++
          [ text "In the context" <+> quotes (pprTheta ctxt)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>

--- a/compiler/typecheck/TcExpr.hs
+++ b/compiler/typecheck/TcExpr.hs
@@ -1610,19 +1610,19 @@ tcCheckDictAppRoleCriterion matched tau ctxt
        ; let nominals_in_tau  = [tv | (tv, Nominal) <- tvs_with_roles_in_tau]
              nominals_in_dict = [tv | (tv, Nominal) <- tvs_with_roles_in_dict]
              nominals_in_ctxt = [tv | (tv, Nominal) <- tvs_with_roles_in_ctxt]
-       ; unless (null nominals_in_tau) $ addErrTc $ vcat $
+       ; unless (null nominals_in_tau) $ addWarnTc $ vcat $
          not_allowed_msg ++
          [ text "In the function type" <+> quotes (ppr tau)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>
                            text "has role Nominal"
                          | tv <- nominals_in_tau]]
-       ; unless (null nominals_in_dict) $ addErrTc $ vcat $
+       ; unless (null nominals_in_dict) $ addWarnTc $ vcat $
          not_allowed_msg ++
          [ text "In the dictionary type" <+> quotes (ppr dict)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>
                            text "has role Nominal"
                          | tv <- nominals_in_dict]]
-       ; unless (null nominals_in_ctxt) $ addErrTc $ vcat $
+       ; unless (null nominals_in_ctxt) $ addWarnTc $ vcat $
          not_allowed_msg ++
          [ text "In the context" <+> quotes (pprTheta ctxt)
          , nest 2 $ vcat [ text "Type variable" <+> quotes (ppr tv) <+>


### PR DESCRIPTION
Thomas,

Deze PR in je GHC branch een wijziging gemaakt om van de role errors warnings te maken.
Er zijn namelijk nogal wat gevallen waar rollen slecht geïnfereerd worden, vaak omwille van het gebrek aan higher-order rollen.
Een student die zijn bachelorthesis bij mij maakt heeft dit nodig om bijvoorbeeld MonadWriter dictionaries te kunnen instantiëren.

groetjes
Dominique